### PR TITLE
Update AprilTagPoseEstimator docs

### DIFF
--- a/src/main/cpp/AprilTagPoseEstimator.cpp
+++ b/src/main/cpp/AprilTagPoseEstimator.cpp
@@ -4,12 +4,12 @@
 using namespace frc;
 
 // this function expects to get the april tag the april tag pose reading in the following format:
-// x - 1st value from jetson
-// y - 2nd value from jetson
-// z - 3rd value from jetson
-// roll (x, 1st value in rotation3d) - 4th value from jetson
-// pitch (y, 2nd value in rotation3d) - 5th value from jetson
-// yaw (z, 3rd value in rotation3d) - 6th value from jetson
+// x - 3rd value from jetson
+// y - 4th value from jetson
+// z - doesn't matter, can be left 0
+// roll (x, 1st value in rotation3d) - doesn't matter, can be left 0
+// pitch (y, 2nd value in rotation3d) - doesn't matter, can be left 0
+// yaw (z, 3rd value in rotation3d) - 4th value from jetson
 // aprilTagNum: april tag number
 Pose2d AprilTagPoseEstimator::getPose(Pose3d aprilTagPosReading, int aprilTagNum) {
     units::meter_t x = aprilTagPosReading.X();

--- a/src/main/cpp/AprilTagPoseEstimator.cpp
+++ b/src/main/cpp/AprilTagPoseEstimator.cpp
@@ -10,7 +10,7 @@ using namespace frc;
 // roll (x, 1st value in rotation3d) - doesn't matter, can be left 0
 // pitch (y, 2nd value in rotation3d) - doesn't matter, can be left 0
 // yaw (z, 3rd value in rotation3d) - 4th value from jetson
-// aprilTagNum: april tag number
+// aprilTagNum: april tag number - 2nd value from jetson
 Pose2d AprilTagPoseEstimator::getPose(Pose3d aprilTagPosReading, int aprilTagNum) {
     units::meter_t x = aprilTagPosReading.X();
     units::meter_t y = aprilTagPosReading.Y();


### PR DESCRIPTION
The order of values we get from the jetson has changed, so I updated the docs to avoid confusion.

Method to return the robot position automatically based on apriltag readings (no parameters required, the method will get the data directly from networktables itself) coming tomorrow.